### PR TITLE
Change ovs-vswitchd service startup type and add triggerinfo

### DIFF
--- a/openvswitch-hyperv-installer/CustomActions.wxs
+++ b/openvswitch-hyperv-installer/CustomActions.wxs
@@ -63,5 +63,12 @@
     <CustomAction Id="ChangeOvsVSwitchdService"
               BinaryKey="OVSActions"
               JScriptCall="changeServiceAction" Execute="deferred" Return="check" Impersonate="no" />
+
+    <CustomAction Id="AddTriggerToOvsVswitchdService_Prop" Property="AddTriggerToOvsVswitchdService"
+                  Value='"[System64Folder]sc.exe" triggerinfo ovs-vswitchd "start/strcustom/6066F867-7CA1-4418-85FD-36E3F9C0600C/VmmsWmiEventProvider"|0|failed to add triggerinfo to ovs-vswitchd service'
+                  Execute="immediate" />
+    <CustomAction Id="AddTriggerToOvsVswitchdService"
+              BinaryKey="OVSActions"
+              JScriptCall="runCommandAction" Execute="deferred" Return="check" Impersonate="no" />
   </Fragment>
 </Wix>

--- a/openvswitch-hyperv-installer/Product.wxs
+++ b/openvswitch-hyperv-installer/Product.wxs
@@ -77,6 +77,9 @@
       <Custom Action="InitializeDB_Prop" After="CostFinalize"><![CDATA[REMOVE <> "ALL" AND (&OpenvSwitchDriver = 3)]]></Custom>
       <Custom Action="InitializeDB" After="ChangeOvsdbServerService" ><![CDATA[REMOVE <> "ALL" AND (&OpenvSwitchDriver = 3)]]></Custom>
 
+      <Custom Action="AddTriggerToOvsVswitchdService_Prop" After="CostFinalize"><![CDATA[NOT Installed AND (&OpenvSwitchDriver = 3)]]></Custom>
+      <Custom Action="AddTriggerToOvsVswitchdService" Before="ChangeOvsVSwitchdService"><![CDATA[NOT Installed AND (&OpenvSwitchDriver = 3)]]></Custom>
+
       <Custom Action="StartOvsVSwitchdService_Prop" After="CostFinalize"><![CDATA[NOT Installed AND (&OpenvSwitchDriver = 3)]]></Custom>
       <Custom Action="RestartOvsVSwitchdService_Prop" After="CostFinalize"><![CDATA[Installed AND REMOVE <> "ALL" AND (&OpenvSwitchDriver = 3)]]></Custom>
       <Custom Action="ChangeOvsVSwitchdService" Before="InstallFinalize"><![CDATA[REMOVE <> "ALL" AND (&OpenvSwitchDriver = 3)]]></Custom>
@@ -203,7 +206,7 @@
                 Name="ovs-vswitchd"
                 DisplayName="Open vSwitch Service"
                 Description="Open vSwitch Service"
-                Start="auto"
+                Start="demand"
                 Account="LocalSystem"
                 ErrorControl="ignore"
                 Interactive="no">


### PR DESCRIPTION
This patch changes the service ovs-vswitchd from "auto" execution to "demand" start.

This patch also introduces a custom action for the ovs-vswitchd service in which
the following command will be executed before the service startup:

sc triggerinfo ovs-vswitchd start/strcustom/6066F867-7CA1-4418-85FD-36E3F9C0600C/VmmsWmiEventProvider

The above command is a service trigger available since Windows 7.
More on the topic: https://msdn.microsoft.com/en-us/library/windows/desktop/dd405513%28v=vs.85%29.aspx

In out case we will wait until Microsoft-Windows-Hyper-V-VMMS has triggered that the
WMI provider: VmmsWmiEventProvider has started.

Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
