### PR TITLE
Split driver pdb file per NT version

### DIFF
--- a/BuildAutomation/BuildOpenvSwitch.ps1
+++ b/BuildAutomation/BuildOpenvSwitch.ps1
@@ -150,6 +150,7 @@ exit
     $sysFileName = "ovsext.sys"
     $infFileName = "ovsext.inf"
     $catFileName = "ovsext.cat"
+    $pdbDriverFileName = "OVSExt.pdb"
 
     pushd .
     try
@@ -159,11 +160,11 @@ exit
         copy -Force "x64\Win8.1Release\package\$sysFileName" $driverOutputPath_2012_r2
         copy -Force "x64\Win8.1Release\package\$infFileName" $driverOutputPath_2012_r2
         copy -Force "x64\Win8.1Release\package\$catFileName" $driverOutputPath_2012_r2
-        copy -Force "ovsext\x64\Win8.1Release\*.pdb" $outputSymbolsPath
+        copy -Force "ovsext\x64\Win8.1Release\$pdbDriverFileName" $driverOutputPath_2012_r2
         copy -Force "x64\Win8Release\package\$sysFileName" $driverOutputPath_2012
         copy -Force "x64\Win8Release\package\$infFileName" $driverOutputPath_2012
         copy -Force "x64\Win8Release\package\$catFileName" $driverOutputPath_2012
-        copy -Force "ovsext\x64\Win8Release\*.pdb" $outputSymbolsPath
+        copy -Force "ovsext\x64\Win8Release\$pdbDriverFileName" $driverOutputPath_2012
     }
     finally
     {

--- a/openvswitch-hyperv-installer/Product.wxs
+++ b/openvswitch-hyperv-installer/Product.wxs
@@ -239,12 +239,14 @@
           <File Id='win8_ovsext.sys' Name='ovsext.sys' DiskId='1' Source='Driver\Win8\ovsext.sys' Checksum='yes' KeyPath='yes' />
           <File Id='win8_ovsext.inf' Name='ovsext.inf' DiskId='1' Source='Driver\Win8\ovsext.inf' Checksum='yes' />
           <File Id='win8_ovsext.cat' Name='ovsext.cat' DiskId='1' Source='Driver\Win8\ovsext.cat' Checksum='yes' />
+          <File Id='win8_ovsext.pdb' Name='OVSExt.pdb' DiskId='1' Source='Driver\Win8\OVSExt.pdb' Checksum='yes' />
      </Component>
      <Component Id='OpenvSwitchDriver_Win8.1' Guid='{7A1E2446-8196-4738-8362-5CFD55896A7C}'>
         <Condition><![CDATA[VersionNT >= "603"]]></Condition>
           <File Id='win81_ovsext.sys' Name='ovsext.sys' DiskId='1' Source='Driver\Win8.1\ovsext.sys' Checksum='yes' KeyPath='yes'/>
           <File Id='win81_ovsext.inf' Name='ovsext.inf' DiskId='1' Source='Driver\Win8.1\ovsext.inf' Checksum='yes' />
           <File Id='win81_ovsext.cat' Name='ovsext.cat' DiskId='1' Source='Driver\Win8.1\ovsext.cat' Checksum='yes' />
+          <File Id='win81_ovsext.pdb' Name='OVSExt.pdb' DiskId='1' Source='Driver\Win8.1\OVSExt.pdb' Checksum='yes' />
       </Component>
     </DirectoryRef>
   </Fragment>


### PR DESCRIPTION
This patch splits the PDB file of the driver per NT version and integrates
it in the installer.

Signed-off-by: Alin Gabriel Serdean aserdean@cloudbasesolutions.com
