### PR TITLE
installer: Create zip of all the userspace symbols

### DIFF
--- a/BuildAutomation/BuildOpenvSwitchSetup.ps1
+++ b/BuildAutomation/BuildOpenvSwitchSetup.ps1
@@ -74,6 +74,7 @@ try
     CheckRemoveDir $ovsSymbolsDir
     mkdir $ovsSymbolsDir
     copy -Force "$buildOutputSymbolsDir\*" $ovsSymbolsDir
+    Compress7z $ovsSymbolsDir "symbols"
 
     pushd .
     try

--- a/BuildAutomation/BuildUtils.ps1
+++ b/BuildAutomation/BuildUtils.ps1
@@ -115,6 +115,21 @@ function Expand7z($archive, $outputDir = ".")
     }
 }
 
+function Compress7z($inputDir, $outputName, $outputDir = ".")
+{
+    pushd .
+    try
+    {
+        cd "$outputDir"
+        &7z a -tzip "$outputName.$type" "$inputDir"
+        if ($LastExitCode) { throw "7z.exe failed to create archive: $outputName"}
+    }
+    finally
+    {
+        popd
+    }
+}
+
 function PullRelease($project, $release, $version)
 {
     pushd .


### PR DESCRIPTION
Add a new function called `Compress7z` which uses 7zip to create a new
archive of the file specified in `inputDir` with the name `outputName`.zip
in the directory `outputDir`

Call the new function when generating the OVS installer.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>